### PR TITLE
Improve Geometrical Dominator slope handling

### DIFF
--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -3877,7 +3877,7 @@ if (!this._state.isFlying && !this._state.isWave && !this._state.isUfo) {
   if (this._state.isBall) {
     const ballOnSurface = this._state.onGround || this._state.onCeiling;
     this._player.updateBallRoll(horizontalDelta, ballOnSurface);
-  } else if (this._state.isOnSlope || (this._state.wasOnSlope && this._state.onGround && this._state.slopeExitGrace > 0)) {
+  } else if (this._state.isOnSlope) {
     this._player.updateSlopeRotation(verticalDelta);
   } else if (this._state.wasOnSlope && this._state.onGround && !this._state.isOnSlope) {
     // Just left a slope; ease rotation back to flat instead of snapping.

--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -3879,7 +3879,7 @@ if (!this._state.isFlying && !this._state.isWave && !this._state.isUfo) {
     this._player.updateBallRoll(horizontalDelta, ballOnSurface);
   } else if (this._state.isOnSlope) {
     this._player.updateSlopeRotation(verticalDelta);
-  } else if (this._state.wasOnSlope && this._state.onGround && !this._state.isOnSlope) {
+  } else if ((this._state.wasOnSlope || this._state.slopeExitRotationTarget !== null) && this._state.onGround && !this._state.isOnSlope) {
     // Just left a slope; ease rotation back to flat instead of snapping.
     this._player.updateSlopeExitRotation(verticalDelta);
   } else if (this._state.onGround) {

--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -3877,7 +3877,7 @@ if (!this._state.isFlying && !this._state.isWave && !this._state.isUfo) {
   if (this._state.isBall) {
     const ballOnSurface = this._state.onGround || this._state.onCeiling;
     this._player.updateBallRoll(horizontalDelta, ballOnSurface);
-  } else if (this._state.isOnSlope) {
+  } else if (this._state.isOnSlope || (this._state.wasOnSlope && this._state.onGround && this._state.slopeExitGrace > 0)) {
     this._player.updateSlopeRotation(verticalDelta);
   } else if (this._state.wasOnSlope && this._state.onGround && !this._state.isOnSlope) {
     // Just left a slope; ease rotation back to flat instead of snapping.

--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -3877,7 +3877,7 @@ if (!this._state.isFlying && !this._state.isWave && !this._state.isUfo) {
   if (this._state.isBall) {
     const ballOnSurface = this._state.onGround || this._state.onCeiling;
     this._player.updateBallRoll(horizontalDelta, ballOnSurface);
-  } else if (this._state.isOnSlope || this._state.wasOnSlope) {
+  } else if (this._state.isOnSlope) {
     this._player.updateSlopeRotation(verticalDelta);
   } else if (this._state.onGround) {
     this._player.updateGroundRotation(verticalDelta);

--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -3879,6 +3879,9 @@ if (!this._state.isFlying && !this._state.isWave && !this._state.isUfo) {
     this._player.updateBallRoll(horizontalDelta, ballOnSurface);
   } else if (this._state.isOnSlope) {
     this._player.updateSlopeRotation(verticalDelta);
+  } else if (this._state.wasOnSlope && this._state.onGround && !this._state.isOnSlope) {
+    // Just left a slope; ease rotation back to flat instead of snapping.
+    this._player.updateSlopeExitRotation(verticalDelta);
   } else if (this._state.onGround) {
     this._player.updateGroundRotation(verticalDelta);
   } else if (this._player.rotateActionActive) {

--- a/assets/scripts/core/level.js
+++ b/assets/scripts/core/level.js
@@ -1191,16 +1191,28 @@ window.LevelObject = class LevelObject {
             if (_nr === 90) { const _t = _fx; _fx = !_fy; _fy = _t; }
             else if (_nr === 180) { _fx = !_fx; _fy = !_fy; }
             else if (_nr === 270) { const _t = _fx; _fx = _fy; _fy = !_t; }
-            let _slopeCol = new Collider(slopeType, worldX, worldY, _0x10e5ae, _0x11e08d, levelObj.rot || 0);
-            _slopeCol.slopeDir = _fx ? -1 : 1;
-            _slopeCol.slopeFlipY = _fy;
-            _slopeCol.slopeFloorTop = _fy;
-            _slopeCol.slopeAngleDeg = _SLOPE_DATA[levelObj.id].angle || 45;
-            _slopeCol.slopeIsFilled = _SLOPE_DATA[levelObj.id].sq || false;
-            _slopeCol.objid = levelObj.id;
-            _registerCollider(_slopeCol);
-            this.objects.push(_slopeCol);
-            this._addCollisionToSection(_slopeCol);
+            const _slopeDir = _fx ? -1 : 1;
+            const _coveredBySlope = this.objects.some(col =>
+              col.type === slopeType &&
+              Math.abs(col.x - worldX) < 0.01 &&
+              Math.abs(col.y - worldY) < 0.01 &&
+              col.slopeDir === _slopeDir &&
+              col.slopeFlipY === _fy &&
+              col.w >= _0x10e5ae - 1 &&
+              col.h >= _0x11e08d - 1
+            );
+            if (!_coveredBySlope) {
+              let _slopeCol = new Collider(slopeType, worldX, worldY, _0x10e5ae, _0x11e08d, levelObj.rot || 0);
+              _slopeCol.slopeDir = _slopeDir;
+              _slopeCol.slopeFlipY = _fy;
+              _slopeCol.slopeFloorTop = _fy;
+              _slopeCol.slopeAngleDeg = _SLOPE_DATA[levelObj.id].angle || 45;
+              _slopeCol.slopeIsFilled = _SLOPE_DATA[levelObj.id].sq || false;
+              _slopeCol.objid = levelObj.id;
+              _registerCollider(_slopeCol);
+              this.objects.push(_slopeCol);
+              this._addCollisionToSection(_slopeCol);
+            }
           } else {
             let _0x4628ff = new Collider(solidType, worldX, worldY, _0x10e5ae, _0x11e08d, levelObj.rot || 0);
             _0x4628ff.objid = levelObj.id;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -41,6 +41,7 @@ class PlayerState {
     this.currentSlopeAngle = 0;
     this.currentSlopeDir = 1;
     this.lastSlopeAngle = 0;
+    this.slopeExitGrace = 0;
   }
 }
 
@@ -1641,8 +1642,7 @@ if (this.p.isFlying || this.p.isUfo) {
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
     const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
-    // Smooth exponential interpolation for slope rotation without snapping ahead of long ramps.
-    const _speed = 14;
+    const _speed = 30;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;
   }
@@ -2541,6 +2541,7 @@ _updateBallJump(_0x2fe319) {
       this.p.currentSlopeAngle = _floorSlopeHit.angle;
       this.p.lastSlopeAngle = _floorSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
+      this.p.slopeExitGrace = 3;
       const _slopeYVel = (gameObj.h * playerSpeed) / gameObj.w;
       const _slopeVelMult = Math.min(1.12 / Math.max(_floorSlopeHit.angle, 0.01), 1.54);
       const _slopeDir = gameObj.slopeDir || 1;
@@ -2559,12 +2560,15 @@ _updateBallJump(_0x2fe319) {
       this.p.currentSlopeAngle = _ceilingSlopeHit.angle;
       this.p.lastSlopeAngle = _ceilingSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
+      this.p.slopeExitGrace = 3;
       this.stopRotation();
       if (!this.p.isFlying) this._checkSnapJump(gameObj);
     } else if (_slopeDeath) {
       this._lastDeathReason = _slopeDeath;
       this.killPlayer();
       return;
+    } else if (this.p.wasOnSlope && this.p.slopeExitGrace > 0) {
+      this.p.slopeExitGrace--;
     }
     if (this.p.collideTop !== 0 && this.p.collideBottom !== 0) {
       if (Math.abs(this.p.collideTop - this.p.collideBottom) < 48) {

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1641,7 +1641,14 @@ if (this.p.isFlying || this.p.isUfo) {
     }
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
-    this._rotation = _targetRad;
+    const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
+    if (Math.abs(_angleDiff) < 0.01) {
+      this._rotation = _targetRad;
+      return;
+    }
+    const _speed = 14;
+    const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
+    this._rotation += _angleDiff * _blend;
   }
   updateSlopeExitRotation(dt) {
     // Called the frame(s) after the player leaves a slope but is still on the ground.

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -42,6 +42,7 @@ class PlayerState {
     this.currentSlopeDir = 1;
     this.lastSlopeAngle = 0;
     this.slopeExitGrace = 0;
+    this.slopeExitRotationTarget = null;
   }
 }
 
@@ -1639,6 +1640,7 @@ if (this.p.isFlying || this.p.isUfo) {
     if (this.p.isBall || this.p.isWave || this.p.isSpider) {
       return;
     }
+    this.p.slopeExitRotationTarget = null;
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _sideStep = Math.PI / 2;
     const _baseSlopeRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
@@ -1659,9 +1661,25 @@ if (this.p.isFlying || this.p.isUfo) {
     if (this.p.isBall || this.p.isWave || this.p.isSpider) {
       return;
     }
-    const _targetRad = this.convertToClosestRotation();
+    const _sideStep = Math.PI / 2;
+    const _backwardDir = -this.flipMod();
+    if (this.p.slopeExitRotationTarget === null) {
+      const _scaledRotation = this._rotation / _sideStep;
+      this.p.slopeExitRotationTarget = _backwardDir < 0
+        ? Math.floor(_scaledRotation) * _sideStep
+        : Math.ceil(_scaledRotation) * _sideStep;
+      if (Math.abs(this.p.slopeExitRotationTarget - this._rotation) < 0.01) {
+        this.p.slopeExitRotationTarget += _backwardDir * _sideStep;
+      }
+    }
+    const _targetRad = this.p.slopeExitRotationTarget;
     const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
-    const _speed = 8;
+    if (Math.abs(_angleDiff) < 0.01) {
+      this._rotation = _targetRad;
+      this.p.slopeExitRotationTarget = null;
+      return;
+    }
+    const _speed = 12;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;
   }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1186,6 +1186,9 @@ if (this.p.isFlying || this.p.isUfo) {
     if (this.p.isDead) {
       return;
     }
+    if (window.debugCollisions && this._lastDeathReason) {
+      console.log("death reason", this._lastDeathReason);
+    }
     this.p.isDead = true;
     this._scene.toggleGlitter(false);
     this._particleEmitter.stop();
@@ -1933,6 +1936,9 @@ _updateBallJump(_0x2fe319) {
     let _0x30410f = false;
     let _boostedThisStep = false;
     const _0x198534 = this._gameLayer.getNearbySectionObjects(pieceWidth);
+    let _floorSlopeHit = null;
+    let _ceilingSlopeHit = null;
+    let _slopeDeath = null;
     for (let gameObj of _0x198534) {
       let left = gameObj.x - gameObj.w / 2;
       let right = gameObj.x + gameObj.w / 2;
@@ -2360,6 +2366,7 @@ _updateBallJump(_0x2fe319) {
             const _hMinDist = gameObj.hitbox_radius + (this.p.isWave ? waveHitSize : playerSize);
             if (_hDistSq > _hMinDist * _hMinDist) continue;
           }
+          this._lastDeathReason = { reason: "hazard", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y };
           this.killPlayer();
           return;
         } else if (_colType === solidType) {
@@ -2387,7 +2394,9 @@ _updateBallJump(_0x2fe319) {
           const isstandingOnAPlatform = this.p.gravityFlipped ? _0xLandTop : _0xLandBot;
           if (iscolliding && !isstandingOnAPlatform) {
             if (window.noClip) this.p.diedThisFrame = true;
+            if (gameObj.h <= 4 || gameObj.w <= 4) continue;
             if (window.noClip || gameObj.objid === 143) continue
+            this._lastDeathReason = { reason: "solid-side", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y, left, right, top, bottom };
             this.killPlayer();
             return;
           }
@@ -2442,6 +2451,7 @@ _updateBallJump(_0x2fe319) {
               if (iscolliding) {
                 if (window.noClip) this.p.diedThisFrame = true;
                 if (window.noClip || gameObj.objid === 143) continue;
+                this._lastDeathReason = { reason: "solid-head", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y, left, right, top, bottom };
                 this.killPlayer();
                 return;
               }
@@ -2469,35 +2479,18 @@ _updateBallJump(_0x2fe319) {
               const _playerBot = playersY - _playerRadOnSlope + gamemodeAddition;
               const _lastBot = playersLastY - _playerRadOnSlope + gamemodeAddition;
               if ((_playerBot >= _surfY || _lastBot >= _surfY) && (this.p.yVelocity <= 0 || this.p.onGround)) {
-                this.p.y = _surfY + _playerRadOnSlope;
-                const _oldVel = this.p.yVelocity;
-                this.hitGround();
-                _0x30410f = true;
-                this.p.collideBottom = _surfY;
-                this.p.isOnSlope = true;
-                this.p.currentSlopeAngle = _slopeAngleRad;
-                this.p.currentSlopeDir = gameObj.slopeDir || 1;
-                const _slopeYVel = (gameObj.h * playerSpeed) / gameObj.w;
-                const _slopeVelMult = Math.min(1.12 / Math.max(_slopeAngleRad, 0.01), 1.54);
-                const _slopeDir = gameObj.slopeDir || 1;
-                const _playerUphill = _slopeDir < 0;
-                this.p.slopeVelocity = _slopeVelMult * _slopeYVel * this.flipMod() * (_playerUphill ? -1 : 1);
-                if (!this.p.isFlying) this._checkSnapJump(gameObj);
+                if (!_floorSlopeHit || _surfY > _floorSlopeHit.surfY) {
+                  _floorSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad };
+                }
                 continue;
               }
             } else {
               const _playerTop = playersY + _playerRadOnSlope - gamemodeAddition;
               const _lastTop = playersLastY + _playerRadOnSlope - gamemodeAddition;
               if ((_playerTop <= _surfY || _lastTop <= _surfY) && (this.p.yVelocity >= 0 || this.p.onGround)) {
-                this.p.y = _surfY - _playerRadOnSlope;
-                this.hitGround();
-                _0x30410f = true;
-                this.p.onCeiling = true;
-                this.p.collideTop = _surfY;
-                this.p.isOnSlope = true;
-                this.p.currentSlopeAngle = _slopeAngleRad;
-                this.p.currentSlopeDir = gameObj.slopeDir || 1;
-                if (!this.p.isFlying) this._checkSnapJump(gameObj);
+                if (!_ceilingSlopeHit || _surfY < _ceilingSlopeHit.surfY) {
+                  _ceilingSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad };
+                }
                 continue;
               }
             }
@@ -2507,12 +2500,45 @@ _updateBallJump(_0x2fe319) {
               const _inside = _slopeUpsideDown ? (playersY + 9 > _surfY) : (playersY - 9 < _surfY);
               if (_inside) {
                 if (window.noClip) { this.p.diedThisFrame = true; continue; }
-                if (gameObj.objid !== 143) { this.killPlayer(); return; }
+                if (gameObj.objid !== 143) {
+                  _slopeDeath = { reason: "slope-inside", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y, left, right, top, bottom, surfY: _surfY };
+                }
               }
             }
           }
         }
       }
+    }
+    if (_floorSlopeHit) {
+      const gameObj = _floorSlopeHit.obj;
+      this.p.y = _floorSlopeHit.surfY + _floorSlopeHit.playerRad;
+      this.hitGround();
+      _0x30410f = true;
+      this.p.collideBottom = _floorSlopeHit.surfY;
+      this.p.isOnSlope = true;
+      this.p.currentSlopeAngle = _floorSlopeHit.angle;
+      this.p.currentSlopeDir = gameObj.slopeDir || 1;
+      const _slopeYVel = (gameObj.h * playerSpeed) / gameObj.w;
+      const _slopeVelMult = Math.min(1.12 / Math.max(_floorSlopeHit.angle, 0.01), 1.54);
+      const _slopeDir = gameObj.slopeDir || 1;
+      const _playerUphill = _slopeDir < 0;
+      this.p.slopeVelocity = _slopeVelMult * _slopeYVel * this.flipMod() * (_playerUphill ? -1 : 1);
+      if (!this.p.isFlying) this._checkSnapJump(gameObj);
+    } else if (_ceilingSlopeHit) {
+      const gameObj = _ceilingSlopeHit.obj;
+      this.p.y = _ceilingSlopeHit.surfY - _ceilingSlopeHit.playerRad;
+      this.hitGround();
+      _0x30410f = true;
+      this.p.onCeiling = true;
+      this.p.collideTop = _ceilingSlopeHit.surfY;
+      this.p.isOnSlope = true;
+      this.p.currentSlopeAngle = _ceilingSlopeHit.angle;
+      this.p.currentSlopeDir = gameObj.slopeDir || 1;
+      if (!this.p.isFlying) this._checkSnapJump(gameObj);
+    } else if (_slopeDeath) {
+      this._lastDeathReason = _slopeDeath;
+      this.killPlayer();
+      return;
     }
     if (this.p.collideTop !== 0 && this.p.collideBottom !== 0) {
       if (Math.abs(this.p.collideTop - this.p.collideBottom) < 48) {

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -2549,6 +2549,21 @@ _updateBallJump(_0x2fe319) {
                 if (!_floorSlopeHit || _distY < _floorSlopeHit.distY || (_distY === _floorSlopeHit.distY && _surfY > _floorSlopeHit.surfY)) {
                   _floorSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad, distY: _distY };
                 }
+                if (this.p.isFlying || this.p.isShip || this.p.isWave || this.p.isBird || this.p.isDart) {
+                  this.p.y = _surfY + _playerRadOnSlope;
+                  this.p.onGround = true;
+                  this.p.yVelocity = 0;
+                  this.p.canJump = true;
+                  this.p.collideBottom = _surfY;
+                  this.hitGround();
+                  this.p.isOnSlope = false;
+                  this.p.wasOnSlope = false;
+                  this.p.slopeVelocity = 0;
+                  this.p.currentSlopeAngle = 0;
+                  _floorSlopeHit = null;
+                  _0x30410f = true;
+                  continue;
+                }
                 continue;
               }
             } else {
@@ -2559,6 +2574,21 @@ _updateBallJump(_0x2fe319) {
                 const _distY = Math.abs(_targetY - playersY);
                 if (!_ceilingSlopeHit || _distY < _ceilingSlopeHit.distY || (_distY === _ceilingSlopeHit.distY && _surfY < _ceilingSlopeHit.surfY)) {
                   _ceilingSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad, distY: _distY };
+                }
+                if (this.p.isFlying || this.p.isShip || this.p.isWave || this.p.isBird || this.p.isDart) {
+                  this.p.y = _surfY - _playerRadOnSlope;
+                  this.p.onGround = true;
+                  this.p.yVelocity = 0;
+                  this.p.canJump = true;
+                  this.p.collideTop = _surfY;
+                  this.hitGround();
+                  this.p.isOnSlope = false;
+                  this.p.wasOnSlope = false;
+                  this.p.slopeVelocity = 0;
+                  this.p.currentSlopeAngle = 0;
+                  _ceilingSlopeHit = null;
+                  _0x30410f = true;
+                  continue;
                 }
                 continue;
               }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1641,10 +1641,7 @@ if (this.p.isFlying || this.p.isUfo) {
     }
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
-    const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
-    const _speed = 30;
-    const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
-    this._rotation += _angleDiff * _blend;
+    this._rotation = _targetRad;
   }
   updateSlopeExitRotation(dt) {
     // Called the frame(s) after the player leaves a slope but is still on the ground.

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -2541,7 +2541,7 @@ _updateBallJump(_0x2fe319) {
       this.p.currentSlopeAngle = _floorSlopeHit.angle;
       this.p.lastSlopeAngle = _floorSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
-      this.p.slopeExitGrace = 3;
+      this.p.slopeExitGrace = 20;
       const _slopeYVel = (gameObj.h * playerSpeed) / gameObj.w;
       const _slopeVelMult = Math.min(1.12 / Math.max(_floorSlopeHit.angle, 0.01), 1.54);
       const _slopeDir = gameObj.slopeDir || 1;
@@ -2560,7 +2560,7 @@ _updateBallJump(_0x2fe319) {
       this.p.currentSlopeAngle = _ceilingSlopeHit.angle;
       this.p.lastSlopeAngle = _ceilingSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
-      this.p.slopeExitGrace = 3;
+      this.p.slopeExitGrace = 20;
       this.stopRotation();
       if (!this.p.isFlying) this._checkSnapJump(gameObj);
     } else if (_slopeDeath) {

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -43,6 +43,7 @@ class PlayerState {
     this.lastSlopeAngle = 0;
     this.slopeExitGrace = 0;
     this.slopeExitRotationTarget = null;
+    this.holdSlopeExitRotation = false;
   }
 }
 
@@ -1570,6 +1571,7 @@ if (this.p.isFlying || this.p.isUfo) {
       this.p.canJump = false;
   }
   runRotateAction() {
+    this.p.holdSlopeExitRotation = false;
     this.rotateActionActive = true;
     this.rotateActionTime = 0;
     const _miniDurScale = this.p.isMini ? (1 / 1.4) : 1;
@@ -1631,6 +1633,9 @@ if (this.p.isFlying || this.p.isUfo) {
     if (this.p.isBall || this.p.isWave || this.p.isSpider) {
       return;
     }
+    if (this.p.holdSlopeExitRotation) {
+      return;
+    }
     let _0x183c2a = this.convertToClosestRotation();
     let _0x108955 = 0.47250000000000003;
     let _0x17a9a6 = Math.min(_0x5c24f7 * 1, _0x108955 * _0x5c24f7);
@@ -1641,6 +1646,7 @@ if (this.p.isFlying || this.p.isUfo) {
       return;
     }
     this.p.slopeExitRotationTarget = null;
+    this.p.holdSlopeExitRotation = false;
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _sideStep = Math.PI / 2;
     const _baseSlopeRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
@@ -1677,9 +1683,10 @@ if (this.p.isFlying || this.p.isUfo) {
     if (Math.abs(_angleDiff) < 0.01) {
       this._rotation = _targetRad;
       this.p.slopeExitRotationTarget = null;
+      this.p.holdSlopeExitRotation = true;
       return;
     }
-    const _speed = 12;
+    const _speed = 22;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;
   }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -2580,6 +2580,13 @@ _updateBallJump(_0x2fe319) {
         }
       }
     }
+    if (this.p.isFlying || this.p.isShip || this.p.isWave || this.p.isBird || this.p.isDart) {
+      this.p.isOnSlope = false;
+      this.p.wasOnSlope = false;
+      this.p.slopeVelocity = 0;
+      this.p.currentSlopeAngle = 0;
+      return;
+    }
     if (_floorSlopeHit) {
       const gameObj = _floorSlopeHit.obj;
       this.p.y = _floorSlopeHit.surfY + _floorSlopeHit.playerRad;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1639,8 +1639,9 @@ if (this.p.isFlying || this.p.isUfo) {
     }
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
-    const _t = Math.min(dt, 0.47250000000000003 * dt);
-    this._rotation = this.slerp2D(this._rotation, _targetRad, _t);
+    const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
+    const _maxStep = Math.max(0.035, dt * 12);
+    this._rotation += Math.max(-_maxStep, Math.min(_maxStep, _angleDiff));
   }
   updateBallRoll(_0x1dd8af, onSurface) {
     const _0x136f29 = this.p.gravityFlipped ? -1 : 1;
@@ -2523,6 +2524,7 @@ _updateBallJump(_0x2fe319) {
       const _slopeDir = gameObj.slopeDir || 1;
       const _playerUphill = _slopeDir < 0;
       this.p.slopeVelocity = _slopeVelMult * _slopeYVel * this.flipMod() * (_playerUphill ? -1 : 1);
+      this.stopRotation();
       if (!this.p.isFlying) this._checkSnapJump(gameObj);
     } else if (_ceilingSlopeHit) {
       const gameObj = _ceilingSlopeHit.obj;
@@ -2534,6 +2536,7 @@ _updateBallJump(_0x2fe319) {
       this.p.isOnSlope = true;
       this.p.currentSlopeAngle = _ceilingSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
+      this.stopRotation();
       if (!this.p.isFlying) this._checkSnapJump(gameObj);
     } else if (_slopeDeath) {
       this._lastDeathReason = _slopeDeath;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -40,6 +40,7 @@ class PlayerState {
     this.slopeVelocity = 0;
     this.currentSlopeAngle = 0;
     this.currentSlopeDir = 1;
+    this.lastSlopeAngle = 0;
   }
 }
 
@@ -1640,8 +1641,24 @@ if (this.p.isFlying || this.p.isUfo) {
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
     const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
-    const _maxStep = Math.max(0.035, dt * 12);
-    this._rotation += Math.max(-_maxStep, Math.min(_maxStep, _angleDiff));
+    // Smooth exponential interpolation for slope rotation.
+    // Uses a fast blend factor (1 - e^(-speed*dt)) so the rotation eases onto the slope
+    // surface without the angular "ramp" from the old linear clamp approach.
+    const _speed = 35;
+    const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
+    this._rotation += _angleDiff * _blend;
+  }
+  updateSlopeExitRotation(dt) {
+    // Called the frame(s) after the player leaves a slope but is still on the ground.
+    // Smoothly eases the tilt back to flat (0) using exponential decay instead of
+    // a linear clamp, preventing the pop on transition to the next slope or flat ground.
+    if (this.p.isBall || this.p.isWave || this.p.isSpider) {
+      return;
+    }
+    const _angleDiff = Math.atan2(Math.sin(-this._rotation), Math.cos(-this._rotation));
+    const _speed = 35;
+    const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
+    this._rotation += _angleDiff * _blend;
   }
   updateBallRoll(_0x1dd8af, onSurface) {
     const _0x136f29 = this.p.gravityFlipped ? -1 : 1;
@@ -1926,6 +1943,17 @@ _updateBallJump(_0x2fe319) {
     this.p.isOnSlope = false;
     const playerSize = this.p.isMini ? 18 : 30;
     const waveHitSize = this.p.isMini ? 6 : 9;
+    const iscube = !this.p.isFlying && !this.p.isBall && !this.p.isWave && !this.p.isUfo && !this.p.isSpider;
+    let _dynamicSize = playerSize;
+    if (iscube) {
+      if (this.p.wasOnSlope || Math.abs(this._rotation) > 0.01) {
+        const _lastSlopeAngle = this.p.lastSlopeAngle || (45 * Math.PI / 180);
+        const _maxSlopeRad = playerSize / Math.cos(_lastSlopeAngle);
+        const _diff = Math.min(_lastSlopeAngle, Math.abs(this._rotation));
+        const _alignment = _lastSlopeAngle > 0.01 ? (_diff / _lastSlopeAngle) : 0;
+        _dynamicSize = playerSize + (_maxSlopeRad - playerSize) * _alignment;
+      }
+    }
     const pieceWidth = _0x2f5078 + centerX;
     const playersY = this.p.y;
     const playersLastY = this.p.lastY;
@@ -2371,10 +2399,10 @@ _updateBallJump(_0x2fe319) {
           this.killPlayer();
           return;
         } else if (_colType === solidType) {
-          let _0x146a97 = playersY - playerSize + gamemodeAddition;
-          let _0x869e42 = playersLastY - playerSize + gamemodeAddition;
-          let _0x3e7199 = playersY + playerSize - gamemodeAddition;
-          let _0x135a9d = playersLastY + playerSize - gamemodeAddition;
+          let _0x146a97 = playersY - _dynamicSize + gamemodeAddition;
+          let _0x869e42 = playersLastY - _dynamicSize + gamemodeAddition;
+          let _0x3e7199 = playersY + _dynamicSize - gamemodeAddition;
+          let _0x135a9d = playersLastY + _dynamicSize - gamemodeAddition;
           const _0x55559d = 9;
           let iscolliding;
           if (_hasCircleHitbox) {
@@ -2396,14 +2424,14 @@ _updateBallJump(_0x2fe319) {
           if (iscolliding && !isstandingOnAPlatform) {
             if (window.noClip) this.p.diedThisFrame = true;
             if (gameObj.h <= 4 || gameObj.w <= 4) continue;
-            if (window.noClip || gameObj.objid === 143) continue
+            if (window.noClip || gameObj.objid === 143) continue;
             this._lastDeathReason = { reason: "solid-side", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y, left, right, top, bottom };
             this.killPlayer();
             return;
           }
           if (pieceWidth + playerSize - 5 > left && pieceWidth - playerSize + 5 < right) {
             if (!this.p.gravityFlipped && (_0x146a97 >= bottom || _0x869e42 >= bottom) && (this.p.yVelocity <= 0 || this.p.onGround)) {
-              this.p.y = bottom + playerSize;
+              this.p.y = bottom + _dynamicSize;
               this.hitGround();
               _0x30410f = true;
               this.p.collideBottom = bottom;
@@ -2413,7 +2441,7 @@ _updateBallJump(_0x2fe319) {
               continue;
             }
             if (this.p.gravityFlipped && !this.p.isFlying && (_0x3e7199 <= top || _0x135a9d <= top) && (this.p.yVelocity >= 0 || this.p.onGround)) {
-              this.p.y = top - playerSize;
+              this.p.y = top - _dynamicSize;
               this.hitGround();
               _0x30410f = true;
               this.p.onCeiling = true;
@@ -2425,14 +2453,14 @@ _updateBallJump(_0x2fe319) {
             }
             if (this.p.isUfo) {
               if (!this.p.gravityFlipped && (_0x3e7199 <= top || _0x135a9d <= top) && (this.p.yVelocity >= 0 || this.p.onGround)) {
-                this.p.y = top - playerSize;
+                this.p.y = top - _dynamicSize;
                 this.hitGround();
                 this.p.onCeiling = true;
                 this.p.collideTop = top;
                 continue;
               }
               if (this.p.gravityFlipped && (_0x146a97 >= bottom || _0x869e42 >= bottom) && (this.p.yVelocity <= 0 || this.p.onGround)) {
-                this.p.y = bottom + playerSize;
+                this.p.y = bottom + _dynamicSize;
                 this.hitGround();
                 _0x30410f = true;
                 this.p.onCeiling = true;
@@ -2442,7 +2470,7 @@ _updateBallJump(_0x2fe319) {
               continue;
             }
             if ((_0x3e7199 <= top || _0x135a9d <= top) && (this.p.yVelocity >= 0 || this.p.onGround) && this.p.isFlying) {
-              this.p.y = top - playerSize;
+              this.p.y = top - _dynamicSize;
               this.hitGround();
               this.p.onCeiling = true;
               this.p.collideTop = top;
@@ -2459,7 +2487,7 @@ _updateBallJump(_0x2fe319) {
               continue;
             }
             if (this.p.gravityFlipped && (_0x146a97 >= bottom || _0x869e42 >= bottom) && (this.p.yVelocity <= 0 || this.p.onGround) && this.p.isFlying) {
-              this.p.y = bottom + playerSize;
+              this.p.y = bottom + _dynamicSize;
               this.hitGround();
               _0x30410f = true;
               this.p.onCeiling = true;
@@ -2472,7 +2500,17 @@ _updateBallJump(_0x2fe319) {
             const _surfY = gameObj.getSlopeSurfaceY(pieceWidth);
             if (_surfY === null) continue;
             const _slopeAngleRad = (gameObj.slopeAngleDeg || 45) * Math.PI / 180;
-            const _playerRadOnSlope = playerSize / Math.cos(_slopeAngleRad);
+            const _maxSlopeRad = playerSize / Math.cos(_slopeAngleRad);
+            let _playerRadOnSlope = _maxSlopeRad;
+            if (iscube) {
+              const _flipMod = this.p.gravityFlipped ? -1 : 1;
+              const _targetRad = -gameObj.slopeDir * _slopeAngleRad * _flipMod;
+              const _diff = Math.abs(Math.atan2(Math.sin(this._rotation - _targetRad), Math.cos(this._rotation - _targetRad)));
+              const _maxDiff = Math.abs(_targetRad);
+              const _alignment = _maxDiff > 0.01 ? (1 - _diff / _maxDiff) : 1;
+              const _clampedAlignment = Math.min(1, Math.max(0, _alignment));
+              _playerRadOnSlope = playerSize + (_maxSlopeRad - playerSize) * _clampedAlignment;
+            }
             const _slopeFloorTop = gameObj.slopeFlipY || false;
             const _upsideDown = this.p.gravityFlipped;
             const _slopeUpsideDown = _upsideDown !== _slopeFloorTop;
@@ -2518,6 +2556,7 @@ _updateBallJump(_0x2fe319) {
       this.p.collideBottom = _floorSlopeHit.surfY;
       this.p.isOnSlope = true;
       this.p.currentSlopeAngle = _floorSlopeHit.angle;
+      this.p.lastSlopeAngle = _floorSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
       const _slopeYVel = (gameObj.h * playerSpeed) / gameObj.w;
       const _slopeVelMult = Math.min(1.12 / Math.max(_floorSlopeHit.angle, 0.01), 1.54);
@@ -2535,6 +2574,7 @@ _updateBallJump(_0x2fe319) {
       this.p.collideTop = _ceilingSlopeHit.surfY;
       this.p.isOnSlope = true;
       this.p.currentSlopeAngle = _ceilingSlopeHit.angle;
+      this.p.lastSlopeAngle = _ceilingSlopeHit.angle;
       this.p.currentSlopeDir = gameObj.slopeDir || 1;
       this.stopRotation();
       if (!this.p.isFlying) this._checkSnapJump(gameObj);
@@ -2553,8 +2593,7 @@ _updateBallJump(_0x2fe319) {
       }
     }
     let _0x3020c8 = this._gameLayer.getFloorY();
-    const iscube = !this.p.isFlying && !this.p.isBall && !this.p.isWave && !this.p.isUfo && !this.p.isSpider;
-    const _effectiveSize = this.p.isWave ? waveHitSize : playerSize;
+    const _effectiveSize = this.p.isWave ? waveHitSize : _dynamicSize;
     if (!_0x30410f && !_boostedThisStep) {
       let gravCeilY = this._gameLayer.getCeilingY();
 

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1944,16 +1944,7 @@ _updateBallJump(_0x2fe319) {
     const playerSize = this.p.isMini ? 18 : 30;
     const waveHitSize = this.p.isMini ? 6 : 9;
     const iscube = !this.p.isFlying && !this.p.isBall && !this.p.isWave && !this.p.isUfo && !this.p.isSpider;
-    let _dynamicSize = playerSize;
-    if (iscube) {
-      if (this.p.wasOnSlope || Math.abs(this._rotation) > 0.01) {
-        const _lastSlopeAngle = this.p.lastSlopeAngle || (45 * Math.PI / 180);
-        const _maxSlopeRad = playerSize / Math.cos(_lastSlopeAngle);
-        const _diff = Math.min(_lastSlopeAngle, Math.abs(this._rotation));
-        const _alignment = _lastSlopeAngle > 0.01 ? (_diff / _lastSlopeAngle) : 0;
-        _dynamicSize = playerSize + (_maxSlopeRad - playerSize) * _alignment;
-      }
-    }
+    const _dynamicSize = playerSize;
     const pieceWidth = _0x2f5078 + centerX;
     const playersY = this.p.y;
     const playersLastY = this.p.lastY;
@@ -2508,8 +2499,10 @@ _updateBallJump(_0x2fe319) {
               const _playerBot = playersY - _playerRadOnSlope + gamemodeAddition;
               const _lastBot = playersLastY - _playerRadOnSlope + gamemodeAddition;
               if ((_playerBot >= _surfY || _lastBot >= _surfY) && (this.p.yVelocity <= 0 || this.p.onGround)) {
-                if (!_floorSlopeHit || _surfY > _floorSlopeHit.surfY) {
-                  _floorSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad };
+                const _targetY = _surfY + _playerRadOnSlope;
+                const _distY = Math.abs(_targetY - playersY);
+                if (!_floorSlopeHit || _distY < _floorSlopeHit.distY || (_distY === _floorSlopeHit.distY && _surfY > _floorSlopeHit.surfY)) {
+                  _floorSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad, distY: _distY };
                 }
                 continue;
               }
@@ -2517,8 +2510,10 @@ _updateBallJump(_0x2fe319) {
               const _playerTop = playersY + _playerRadOnSlope - gamemodeAddition;
               const _lastTop = playersLastY + _playerRadOnSlope - gamemodeAddition;
               if ((_playerTop <= _surfY || _lastTop <= _surfY) && (this.p.yVelocity >= 0 || this.p.onGround)) {
-                if (!_ceilingSlopeHit || _surfY < _ceilingSlopeHit.surfY) {
-                  _ceilingSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad };
+                const _targetY = _surfY - _playerRadOnSlope;
+                const _distY = Math.abs(_targetY - playersY);
+                if (!_ceilingSlopeHit || _distY < _ceilingSlopeHit.distY || (_distY === _ceilingSlopeHit.distY && _surfY < _ceilingSlopeHit.surfY)) {
+                  _ceilingSlopeHit = { obj: gameObj, surfY: _surfY, playerRad: _playerRadOnSlope, angle: _slopeAngleRad, distY: _distY };
                 }
                 continue;
               }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -45,6 +45,7 @@ class PlayerState {
     this.slopeExitRotationTarget = null;
     this.holdSlopeExitRotation = false;
     this.suppressNextFallRotate = false;
+    this.slopeExitJumpLandingDir = 0;
   }
 }
 
@@ -1168,6 +1169,16 @@ if (this.p.isFlying || this.p.isUfo) {
     this.p.isJumping = false;
     this.p.queuedHold = false;
     this.p.suppressNextFallRotate = false;
+    if (this.p.slopeExitJumpLandingDir !== 0 && !this.p.isBall && !this.p.isWave && !this.p.isSpider) {
+      const _sideStep = Math.PI / 2;
+      const _scaledRotation = this._rotation / _sideStep;
+      this._rotation = this.p.slopeExitJumpLandingDir > 0
+        ? Math.ceil(_scaledRotation) * _sideStep
+        : Math.floor(_scaledRotation) * _sideStep;
+      this.rotateActionActive = false;
+      this.p.holdSlopeExitRotation = true;
+      this.p.slopeExitJumpLandingDir = 0;
+    }
     if (this.p.isBall) {
       if (_0x4a38a5) {
         this._rotation = Math.round(this._rotation / Math.PI) * Math.PI;
@@ -1575,6 +1586,7 @@ if (this.p.isFlying || this.p.isUfo) {
   runRotateAction() {
     if (this.p.holdSlopeExitRotation && this.p.onGround) {
       this.p.suppressNextFallRotate = true;
+      this.p.slopeExitJumpLandingDir = this.flipMod();
     }
     this.p.holdSlopeExitRotation = false;
     this.rotateActionActive = true;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -2500,17 +2500,7 @@ _updateBallJump(_0x2fe319) {
             const _surfY = gameObj.getSlopeSurfaceY(pieceWidth);
             if (_surfY === null) continue;
             const _slopeAngleRad = (gameObj.slopeAngleDeg || 45) * Math.PI / 180;
-            const _maxSlopeRad = playerSize / Math.cos(_slopeAngleRad);
-            let _playerRadOnSlope = _maxSlopeRad;
-            if (iscube) {
-              const _flipMod = this.p.gravityFlipped ? -1 : 1;
-              const _targetRad = -gameObj.slopeDir * _slopeAngleRad * _flipMod;
-              const _diff = Math.abs(Math.atan2(Math.sin(this._rotation - _targetRad), Math.cos(this._rotation - _targetRad)));
-              const _maxDiff = Math.abs(_targetRad);
-              const _alignment = _maxDiff > 0.01 ? (1 - _diff / _maxDiff) : 1;
-              const _clampedAlignment = Math.min(1, Math.max(0, _alignment));
-              _playerRadOnSlope = playerSize + (_maxSlopeRad - playerSize) * _clampedAlignment;
-            }
+            const _playerRadOnSlope = playerSize / Math.cos(_slopeAngleRad);
             const _slopeFloorTop = gameObj.slopeFlipY || false;
             const _upsideDown = this.p.gravityFlipped;
             const _slopeUpsideDown = _upsideDown !== _slopeFloorTop;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1809,6 +1809,7 @@ if (this.p.isFlying || this.p.isUfo) {
       _0x203040 = -1;
     }
     if (!this.p.upKeyDown && !this.playerIsFalling()) {
+      this.p.queuedHold = false;
       _0x203040 = 1.2;
     }
     let _0x2d237f = 0.4;
@@ -1846,11 +1847,7 @@ _updateBallJump(_0x2fe319) {
     this.p.canJump = false;
     }
     this.p.yVelocity -= _0x144266 * _0x2fe319 * this.flipMod();
-    if (this.p.gravityFlipped) {
-      this.p.yVelocity = Math.min(this.p.yVelocity, 30);
-    } else {
-      this.p.yVelocity = Math.max(this.p.yVelocity, -30);
-    }
+    this.p.yVelocity = Math.max(-30, Math.min(30, this.p.yVelocity));
     if (this.playerIsFalling()) {
       const _0x1439be = this.p.gravityFlipped ? this.p.yVelocity > p * 2 : this.p.yVelocity < -(p * 2);
       if (_0x1439be) {
@@ -2034,6 +2031,22 @@ _updateBallJump(_0x2fe319) {
       }
       if (_broadPhaseHit) {
         const _colType = gameObj.type;
+        if (_colType === hazardType) {
+          if (window.noClip) {
+            this.p.diedThisFrame = true;
+            continue;
+          }
+          if (_hasCircleHitbox) {
+            const _hdx = pieceWidth - gameObj.x;
+            const _hdy = playersY - gameObj.y;
+            const _hDistSq = _hdx * _hdx + _hdy * _hdy;
+            const _hMinDist = gameObj.hitbox_radius + (this.p.isWave ? waveHitSize : playerSize);
+            if (_hDistSq > _hMinDist * _hMinDist) continue;
+          }
+          this._lastDeathReason = { reason: "hazard", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y };
+          this.killPlayer();
+          return;
+        }
         if (_colType === "portal_fly") {
           if (!gameObj.activated) {
             gameObj.activated = true;
@@ -2421,21 +2434,6 @@ _updateBallJump(_0x2fe319) {
               }
             } catch(e) {}
           }
-        } else if (_colType === hazardType) {
-          if (window.noClip) {
-            this.p.diedThisFrame = true; 
-            continue;
-          }
-          if (_hasCircleHitbox) {
-            const _hdx = pieceWidth - gameObj.x;
-            const _hdy = playersY - gameObj.y;
-            const _hDistSq = _hdx * _hdx + _hdy * _hdy;
-            const _hMinDist = gameObj.hitbox_radius + (this.p.isWave ? waveHitSize : playerSize);
-            if (_hDistSq > _hMinDist * _hMinDist) continue;
-          }
-          this._lastDeathReason = { reason: "hazard", objid: gameObj.objid, type: gameObj.type, playerX: pieceWidth, playerY: playersY, objX: gameObj.x, objY: gameObj.y };
-          this.killPlayer();
-          return;
         } else if (_colType === solidType) {
           let _0x146a97 = playersY - _dynamicSize + gamemodeAddition;
           let _0x869e42 = playersLastY - _dynamicSize + gamemodeAddition;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1641,10 +1641,8 @@ if (this.p.isFlying || this.p.isUfo) {
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
     const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
     const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
-    // Smooth exponential interpolation for slope rotation.
-    // Uses a fast blend factor (1 - e^(-speed*dt)) so the rotation eases onto the slope
-    // surface without the angular "ramp" from the old linear clamp approach.
-    const _speed = 35;
+    // Smooth exponential interpolation for slope rotation without snapping ahead of long ramps.
+    const _speed = 14;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;
   }
@@ -1656,7 +1654,7 @@ if (this.p.isFlying || this.p.isUfo) {
       return;
     }
     const _angleDiff = Math.atan2(Math.sin(-this._rotation), Math.cos(-this._rotation));
-    const _speed = 35;
+    const _speed = 8;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;
   }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -1640,7 +1640,9 @@ if (this.p.isFlying || this.p.isUfo) {
       return;
     }
     const _flipMod = this.p.gravityFlipped ? -1 : 1;
-    const _targetRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
+    const _sideStep = Math.PI / 2;
+    const _baseSlopeRad = -this.p.currentSlopeDir * (this.p.currentSlopeAngle || 0) * _flipMod;
+    const _targetRad = _baseSlopeRad + Math.round((this._rotation - _baseSlopeRad) / _sideStep) * _sideStep;
     const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
     if (Math.abs(_angleDiff) < 0.01) {
       this._rotation = _targetRad;
@@ -1657,7 +1659,8 @@ if (this.p.isFlying || this.p.isUfo) {
     if (this.p.isBall || this.p.isWave || this.p.isSpider) {
       return;
     }
-    const _angleDiff = Math.atan2(Math.sin(-this._rotation), Math.cos(-this._rotation));
+    const _targetRad = this.convertToClosestRotation();
+    const _angleDiff = Math.atan2(Math.sin(_targetRad - this._rotation), Math.cos(_targetRad - this._rotation));
     const _speed = 8;
     const _blend = 1 - Math.exp(-_speed * Math.max(dt / 60, 0.00001));
     this._rotation += _angleDiff * _blend;

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -44,6 +44,7 @@ class PlayerState {
     this.slopeExitGrace = 0;
     this.slopeExitRotationTarget = null;
     this.holdSlopeExitRotation = false;
+    this.suppressNextFallRotate = false;
   }
 }
 
@@ -1166,6 +1167,7 @@ if (this.p.isFlying || this.p.isUfo) {
     this.p.canJump = true;
     this.p.isJumping = false;
     this.p.queuedHold = false;
+    this.p.suppressNextFallRotate = false;
     if (this.p.isBall) {
       if (_0x4a38a5) {
         this._rotation = Math.round(this._rotation / Math.PI) * Math.PI;
@@ -1571,6 +1573,9 @@ if (this.p.isFlying || this.p.isUfo) {
       this.p.canJump = false;
   }
   runRotateAction() {
+    if (this.p.holdSlopeExitRotation && this.p.onGround) {
+      this.p.suppressNextFallRotate = true;
+    }
     this.p.holdSlopeExitRotation = false;
     this.rotateActionActive = true;
     this.rotateActionTime = 0;
@@ -1774,7 +1779,7 @@ if (this.p.isFlying || this.p.isUfo) {
       } else {
         this.p.yVelocity = Math.max(this.p.yVelocity, -30);
       }
-      if (this._isFallingPastThreshold() && !this.rotateActionActive) {
+      if (this._isFallingPastThreshold() && !this.rotateActionActive && !this.p.suppressNextFallRotate) {
         this.runRotateAction();
       }
       if (this.playerIsFalling()) {

--- a/assets/scripts/utils/config.js
+++ b/assets/scripts/utils/config.js
@@ -23,6 +23,7 @@ window.orbClickShrinkTime = 250;
 window.orbParticleSize = 3.5;
 
 const urlParams = new URLSearchParams(window.location.search);
+window.debugCollisions = urlParams.has("debugCollisions");
 if (urlParams.has('id')) {
   window.levelID = urlParams.get('id');
 }

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-11"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-12"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-11"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-12"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-8"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-9"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-8"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-9"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-7"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-8"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-6"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-8"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -29,10 +29,10 @@
 	<script src="assets/scripts/api/GDapiWrapper.js"></script>
 	<!-- worker -->
 	<script>window._gdProxyUrl = "https://gd-proxy.gmdc.workers.dev";</script>
-	<script defer src="assets/scripts/utils/config.js"></script>
+	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
-	<script defer src="assets/scripts/core/level.js?latest"></script>
-	<script defer src="assets/scripts/core/player.js"></script>
+	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-debug-3"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
 	<script defer src="assets/scripts/core/game-scene.js?latest"></script>

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-10"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-11"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-10"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-11"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-5"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-6"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-2"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-6"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-6"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-7"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
 	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-6"></script>

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-2"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-3"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
 	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-2"></script>

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-1"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-2"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-1"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-2"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-13"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-14"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-13"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-14"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-12"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-13"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-12"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-13"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-4"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-5"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
 	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-2"></script>

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-9"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-10"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-9"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-10"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-anim-3"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-4"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
 	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-2"></script>

--- a/index.html
+++ b/index.html
@@ -32,10 +32,10 @@
 	<script defer src="assets/scripts/utils/config.js?slopes-debug-1"></script>
 	<script defer src="assets/scripts/core/triggers.js"></script>
 	<script defer src="assets/scripts/core/level.js?slopes-fix-1"></script>
-	<script defer src="assets/scripts/core/player.js?slopes-debug-3"></script>
+	<script defer src="assets/scripts/core/player.js?slopes-anim-1"></script>
 	<script defer src="assets/scripts/core/audio.js"></script>
 	<script defer src="assets/scripts/core/loading-screen.js"></script>
-	<script defer src="assets/scripts/core/game-scene.js?latest"></script>
+	<script defer src="assets/scripts/core/game-scene.js?slopes-anim-1"></script>
 	<script defer src="assets/scripts/core/main.js"></script>
 	<script>
 		new ResizeObserver(() => {


### PR DESCRIPTION
Improves slope collision handling in Geometrical Dominator.

Changes:
- Prevents the player from dying on the second slope.
- Avoids lethal side collisions on very thin trim solids.
- Resolves overlapping slope surfaces once per frame to reduce snapping.
- Adds optional `?debugCollisions=1` death-reason logging for debugging.