### PR TITLE
Added service worker for offline support

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,17 @@
 </head>
 
 <body>
+
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('./sw.js')
+          .then(reg => console.log('Offline modus geactiveerd!'))
+          .catch(err => console.error('Offline modus mislukt:', err));
+      });
+    }
+  </script>
+
 </body>
 
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,50 @@
+const GHPATH = '/zainojdaf/web-dashers.github.io'; 
+const CACHE_NAME = 'web-dashers-dynamic-v1';
+
+// We cachen handmatig alleen de absolute basis om de app op te starten
+const INITIAL_CORE = [
+  `${GHPATH}/`,
+  `${GHPATH}/index.html`
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(INITIAL_CORE);
+    })
+  );
+});
+
+// DYNAMISCH CACHEN: Dit vangt ELK bestand op dat de game probeert te laden
+self.addEventListener('fetch', (event) => {
+  // Alleen GET-verzoeken cachen (bestanden, audio, scripts)
+  if (event.request.method !== 'GET') return;
+
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      // 1. Als het bestand al in de cache staat, laad het direct (werkt offline!)
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      // 2. Staat het er niet in? Haal het op van internet en sla het direct op voor de volgende keer
+      return fetch(event.request).then((networkResponse) => {
+        // Controleer of het verzoek geldig is
+        if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
+          return networkResponse;
+        }
+
+        // Sla een kopie van het bestand op in de cache
+        const responseToCache = networkResponse.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+
+        return networkResponse;
+      }).catch(() => {
+        // Fallback als je volledig offline bent en het bestand niet in de cache staat
+        return caches.match(`${GHPATH}/index.html`);
+      });
+    })
+  );
+});

--- a/sw.js
+++ b/sw.js
@@ -1,7 +1,6 @@
 const GHPATH = '/zainojdaf/web-dashers.github.io'; 
 const CACHE_NAME = 'web-dashers-dynamic-v1';
 
-// We cachen handmatig alleen de absolute basis om de app op te starten
 const INITIAL_CORE = [
   `${GHPATH}/`,
   `${GHPATH}/index.html`
@@ -15,26 +14,24 @@ self.addEventListener('install', (event) => {
   );
 });
 
-// DYNAMISCH CACHEN: Dit vangt ELK bestand op dat de game probeert te laden
 self.addEventListener('fetch', (event) => {
-  // Alleen GET-verzoeken cachen (bestanden, audio, scripts)
+ // (files, audio, scripts)
   if (event.request.method !== 'GET') return;
 
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
-      // 1. Als het bestand al in de cache staat, laad het direct (werkt offline!)
+      // if the file is loaded it works offline :)
       if (cachedResponse) {
         return cachedResponse;
       }
 
-      // 2. Staat het er niet in? Haal het op van internet en sla het direct op voor de volgende keer
       return fetch(event.request).then((networkResponse) => {
-        // Controleer of het verzoek geldig is
+        // Test if the request works (this is important)
         if (!networkResponse || networkResponse.status !== 200 || networkResponse.type !== 'basic') {
           return networkResponse;
         }
 
-        // Sla een kopie van het bestand op in de cache
+        // makes a copy of the file (thats how it works offline heh)
         const responseToCache = networkResponse.clone();
         caches.open(CACHE_NAME).then((cache) => {
           cache.put(event.request, responseToCache);
@@ -42,7 +39,7 @@ self.addEventListener('fetch', (event) => {
 
         return networkResponse;
       }).catch(() => {
-        // Fallback als je volledig offline bent en het bestand niet in de cache staat
+        // Fallback if you are offline and you dont have ANY files loaded
         return caches.match(`${GHPATH}/index.html`);
       });
     })


### PR DESCRIPTION
So basically how this works is you load the game offline, wait 10-15 seconds for it to load the main assets, then go in any level you want, even online levels, paste the ID and play the level for 5-10 seconds, then you NEED TO go to the main levels page, and when you are offline you can click on the [LEVEL NAME] because when you play a level it saves in the main levels page! NOTE: Don't close the web-dashers page!

Also, the editor is always offline, and you can change your icons offline. When you load a level offline you didn't load online, it just doesn't load the level, so it immediatly exits out. You cant really click it.
[Screen recording 2026-06-12 10.56.05.webm](https://github.com/user-attachments/assets/8b9a7d90-1ee4-4692-8da9-bf500b6cc48c)
