### PR TITLE
Fix #172: hitbox trail entries now store deterministic size + isWave

### DIFF
--- a/assets/scripts/core/game-scene.js
+++ b/assets/scripts/core/game-scene.js
@@ -6078,7 +6078,8 @@ _buildSettingsPopup() {
       if (!this._player._scene._slideIn){
         if (!this._player._hitboxTrail) this._player._hitboxTrail = [];
         if (!this._player.p.isDead) {
-          this._player._hitboxTrail.push({ x: this._playerWorldX, y: this._player.p.y, rotation: this._player._rotation });
+          const _trailSize = this._player.p.isMini ? 18 : 30;
+          this._player._hitboxTrail.push({ x: this._playerWorldX, y: this._player.p.y, rotation: this._player._rotation, size: _trailSize, isWave: this._player.p.isWave });
           if (this._player._hitboxTrail.length > 180) this._player._hitboxTrail.shift();
         }
       }

--- a/assets/scripts/core/player.js
+++ b/assets/scripts/core/player.js
@@ -2666,23 +2666,25 @@ _updateWaveJump() {
           const trailXRaw = pos.x - camX;
           const trailX = isFlipped ? screenWidth - trailXRaw : trailXRaw;
           const trailY = b(pos.y) + camY;
+          const entrySize = pos.size ?? (this.p.isMini ? 18 : 30);
+          const entryHitboxSize = entrySize * 2;
           graphics.lineStyle(1, hexToHexadecimal("ff0000"), 1);
 
-          if (!this.p.isWave){
+          if (!pos.isWave){
             // outer box (red)
             graphics.lineStyle(1, hexToHexadecimal("ff0000"), 0.5);
-            graphics.strokeRect(trailX - playerSize, trailY - playerSize, hitboxsize, hitboxsize);
+            graphics.strokeRect(trailX - entrySize, trailY - entrySize, entryHitboxSize, entryHitboxSize);
 
             // inner circle (dark red)
             graphics.lineStyle(1, hexToHexadecimal("b30001"), 0.5);
-            graphics.strokeCircle((trailX - playerSize) + hitboxsize / 2, (trailY - playerSize) + hitboxsize / 2, hitboxsize / 2);
+            graphics.strokeCircle((trailX - entrySize) + entryHitboxSize / 2, (trailY - entrySize) + entryHitboxSize / 2, entryHitboxSize / 2);
 
             // box that rotates with the player (dark red)
             graphics.lineStyle(1, hexToHexadecimal("b30001"), 0.5);
             {
-              const cx = (trailX - playerSize) + hitboxsize / 2;
-              const cy = (trailY - playerSize) + hitboxsize / 2;
-              const hw = hitboxsize / 2;
+              const cx = (trailX - entrySize) + entryHitboxSize / 2;
+              const cy = (trailY - entrySize) + entryHitboxSize / 2;
+              const hw = entryHitboxSize / 2;
               const cos = Math.cos(pos.rotation ?? 0);
               const sin = Math.sin(pos.rotation ?? 0);
               const corners = [


### PR DESCRIPTION
## Root Cause
Hitbox trail rendering read `this.p.isMini` and `this.p.isWave` (current live state) for all historical entries, causing past trail entries to retroactively change size/shape when the player switched gamemodes (cube ↔ mini wave).

## Fix
- **Push** (`game-scene.js:6081`): store pre-computed `size` (18 or 30) and `isWave` per trail entry at record time
- **Render** (`player.js:2669-2706`): use stored `pos.size` and `pos.isWave` instead of live state

Trail entries are now fully deterministic — past frames are immutable regardless of current gamemode.

## Testing
- Toggled cube ↔ mini wave repeatedly
- Confirmed past trail entries do NOT change retroactively
- Current hitbox still matches live gamemode correctly