### PR TITLE
Rename Three Step to Override & nitey to Nightcat

### DIFF
--- a/assets/scripts/game/allLevels.js
+++ b/assets/scripts/game/allLevels.js
@@ -150,10 +150,10 @@ window.allLevels = [
 	    ["Jax", "Step"]
     ],
     [
-        "three_step",
-	    "Three Step",
+        "override",
+	    "override",
 	    "level_137409445",
-	    ["nitey", "DJ-Nate"]
+	    ["Nightcat", "DJ-Nate"]
     ],
     [
         "disco_dinosaur",


### PR DESCRIPTION
This renames Three Step to Override and nitey to Nightcat (crazy, I know). The level was always called Override, in reference to the Chromium local override method of replacing Stereo Madness on geometrydash.com. nitey is my nickname; officially speaking, I go by Nightcat.