### PR TITLE
fix level import

### DIFF
--- a/assets/scripts/core/level.js
+++ b/assets/scripts/core/level.js
@@ -134,22 +134,27 @@ function parseObject(objectString) {
   }
 }
 function parseLevel(levelString) {
-  let decompressedString = function (compressedString) {
-    let getBase64 = function (compressedString) {
-      let lessCluttered = compressedString.replace(/-/g, "+").replace(/_/g, "/");
-      while (lessCluttered.length % 4 != 0) {
-        lessCluttered += "=";
+  let decompressedString = null;
+  try{
+    decompressedString = function (compressedString) {
+      let getBase64 = function (compressedString) {
+        let lessCluttered = compressedString.replace(/-/g, "+").replace(/_/g, "/");
+        while (lessCluttered.length % 4 != 0) {
+          lessCluttered += "=";
+        }
+        return lessCluttered;
+      }(compressedString.trim());
+      let decryptedString = atob(getBase64);
+      let rawBytes = new Uint8Array(decryptedString.length);
+      for (let byteStr = 0; byteStr < decryptedString.length; byteStr++) {
+        rawBytes[byteStr] = decryptedString.charCodeAt(byteStr);
       }
-      return lessCluttered;
-    }(compressedString.trim());
-    let decryptedString = atob(getBase64);
-    let rawBytes = new Uint8Array(decryptedString.length);
-    for (let byteStr = 0; byteStr < decryptedString.length; byteStr++) {
-      rawBytes[byteStr] = decryptedString.charCodeAt(byteStr);
-    }
-    let inflatedBytes = pako.inflate(rawBytes);
-    return new TextDecoder().decode(inflatedBytes);
-  }(levelString);
+      let inflatedBytes = pako.inflate(rawBytes);
+      return new TextDecoder().decode(inflatedBytes);
+    }(levelString);
+  } catch(InvalidCharacterError) {
+    decompressedString = levelString;
+  }
   let stringParts = decompressedString.split(";");
   let settings = stringParts.length > 0 ? stringParts[0] : "";
   let objects = [];


### PR DESCRIPTION
This could be a solution to #234

This is probably just a temporary solution, but it seems to work just fine.

I've tested loading and exporting levels for some time.
By importing and exporting an old level and seeing what changed in the .gmd file. I found that for .gmd files exported with the current version, the `levelString` turns out to be the same as `decompressedString` when loading the original file.

So the idea is simple: if doing it the old way throws an error (specifically `InvalidCharacterError`), we can assume that it is exported with some newer version of web dashers, and for the reason above, we should be able to directly use `levelString` as `decompressedString`.